### PR TITLE
Support new spreadsheet

### DIFF
--- a/lib/Net/Google/Spreadsheets.pm
+++ b/lib/Net/Google/Spreadsheets.pm
@@ -54,11 +54,10 @@ feedurl spreadsheet => (
 
 around spreadsheets => sub {
     my ($next, $self, $args) = @_;
-    my @result = $next->($self, $args);
     if (my $key = $args->{key}) {
-        @result = grep {$_->key eq $key} @result;
+        $args = $self->get_entry("https://spreadsheets.google.com/feeds/spreadsheets/private/full/$key");
     }
-    return @result;
+    return $next->($self, $args);
 };
 
 sub BUILD {

--- a/lib/Net/Google/Spreadsheets/Spreadsheet.pm
+++ b/lib/Net/Google/Spreadsheets/Spreadsheet.pm
@@ -17,10 +17,24 @@ entry_has key => (
     is => 'ro',
     from_atom => sub {
         my ($self, $atom) = @_;
+
+        # find the key for old google spreadsheet
         my ($link) = grep {
             $_->rel eq 'alternate' && $_->type eq 'text/html'
         } $atom->link;
-        return {URI->new($link->href)->query_form}->{key};
+        if(my $key = {URI->new($link->href)->query_form}->{key}) {
+            return $key;
+        }
+
+        # it's new google spreadsheet
+        ($link) = grep {
+            $_->rel eq 'self' && $_->type eq 'application/atom+xml'
+        } $atom->link;
+        if($link->href =~ m(https://spreadsheets.google.com/feeds/spreadsheets/private/full/(.*)$)) {
+            return $1;
+        }
+
+	return ;
     },
 );
 


### PR DESCRIPTION
Hello, lopnor.
I tried to use Net::Google::Spreadsheets with New Google Spreadsheet.

``` perl
my $service = Net::Google::Spreadsheets->new(auth => $auth);

# '1Y-xxxxxxxxxxxxxxxxxxxxxxxxxxxxx' is New Google Spreadsheet
my $spreadsheet = $service->spreadsheet({key => '1Y-xxxxxxxxxxxxxxxxxxxxxxxxxxxxx'});
```

but I got some warnings and it didn't work.

``` plain
Use of uninitialized value $nsURI in string eq at /home/ichinose/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/x86_64-linux/XML/LibXML.pm line 1702.
Use of uninitialized value $nsURI in concatenation (.) or string at /home/ichinose/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/x86_64-linux/XML/LibXML.pm line 1705.
```

it seems that `https://spreadsheets.google.com/feeds/spreadsheets/private/full?key={key}` doesn't work if the key is for New Google Spreadsheet.
I changed that it gets an entry of spreadsheet from specific URL if key is passed.
(see also: https://github.com/gimite/google-drive-ruby)
